### PR TITLE
[FE-#162] Refresh Token 도입으로 인해 로그인 API 응답 수정 

### DIFF
--- a/frontend/src/Modals/LoginForm.js
+++ b/frontend/src/Modals/LoginForm.js
@@ -16,7 +16,7 @@ const LoginForm = ({ onLogin }) => {
   const [modalOpeninfo, setModalOpeninfo] = useState(false);
   const [cookies, setCookie] = useCookies(['accessToken']);
   const [modalOpenin, setModalOpenin] = useState(true);
-  const navigator = useNavigate();
+
 
   useEffect(() => {
     const savedEmail = localStorage.getItem('userEmail');
@@ -72,33 +72,27 @@ const LoginForm = ({ onLogin }) => {
       return;
     }
 
-    const { code, token, expirationTime } = responseBody;
+    const { code, accessToken, refreshToken, expirationTime } = responseBody;
 
-    if (code === 'SU') {
-      if (token && expirationTime) {
-        const now = new Date().getTime();
-        const expires = new Date(now + expirationTime * 1000);
-        setCookie('accessToken', token, { expires, path: '/' });
-        onLogin(true);
-        setModalOpenin(false);
-        window.location.reload();
-      } else {
-        console.error('토큰 또는 만료 시간이 제공되지 않았습니다.');
-        setError(true);
-        onLogin(false);
-      }
+    if (code === 'SU' && accessToken && refreshToken && expirationTime) {
+      const expires = new Date(Date.now() + expirationTime * 1000);
+  
+      
+      setCookie('accessToken', accessToken, { expires, path: '/' });
+  
+      
+      setCookie('refreshToken', refreshToken, { path: '/' });
+  
+      onLogin(true);
+      window.location.reload();
     } else {
       setError(true);
-      if (code === 'DBE') {
-        alert('데이터베이스 오류입니다.');
-      } else if (code === 'SF') {
-        alert('로그인 실패입니다.\n이메일 또는 비밀번호를 확인해주세요.');
-      } else if (code === 'VF') {
-        alert('로그인 실패입니다.');
-      } else {
-        alert('네트워크 오류입니다.');
-        console.error(code);
-      }
+      const messages = {
+        DBE: '데이터베이스 오류입니다.',
+        SF: '로그인 실패입니다. 이메일 또는 비밀번호를 확인해주세요.',
+        VF: '로그인 실패입니다.',
+      };
+      alert(messages[code] || '네트워크 오류입니다.');
     }
   };
 

--- a/frontend/src/apis/index.js
+++ b/frontend/src/apis/index.js
@@ -803,17 +803,16 @@ return result;
 
 //2. 사용자 로그인을 위한 API
 export const signInRequest = async (requestBody) => { 
-    const result = await axios.post(SIGN_IN_URL(), requestBody) 
-        .then(response => {
-            const responseBody = response.data;
-            return responseBody;
-        })
-        .catch(error => {
-            if (!error.response || !error.response.data) return null; 
-            const responseBody = error.response.data;             
-            return responseBody;
-        });
-    return result;
+    try {
+        const response = await axios.post(SIGN_IN_URL(), requestBody);
+        return response.data;  // 정상 응답 시 그대로 반환 (accessToken, refreshToken 포함)
+    } catch (error) {
+        if (error.response && error.response.data) {
+            return error.response.data; // API 에러 응답 반환
+        }
+        console.error('로그인 요청 실패:', error);
+        return { code: 'ERROR', message: '로그인 요청 중 오류 발생' };
+    }
 };
 
 //4. 사용자 정보 수정 API


### PR DESCRIPTION
로그인 API 응답에 리프레시 토큰이 포함되도록 수정하였으며,
이에 따라 클라이언트에서 토큰을 저장하고 갱신할 수 있도록 응답 코드를 조정함.

## PR 종류

- [ ] 기능 개선
- [X] 새로운 기능
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
기존 응답 코드에서 refreshToken을 추가적으로 받는 코드로 수정함 
token 이라는 단일 필드명은 accessToken인지 refreshToken인지 구분이 어려우므로
acessToken과 refreshToken명으로 수정

## 관련 이슈

- #162 

## 체크리스트

- [X] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [X] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?

## 스크린샷

![image](https://github.com/user-attachments/assets/aa91cb8b-3b24-48f0-ad5e-3fb9909aa3fe)


## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
