### PR TITLE
[FE-#152] 반응형을 위한 코딩존 '출석확인' 버튼 너비 표준화 및 상단 여백 조정 

### DIFF
--- a/frontend/src/pages/css/codingzone/codingzone_attend.css
+++ b/frontend/src/pages/css/codingzone/codingzone_attend.css
@@ -81,55 +81,48 @@
     display: flex;
     justify-content: center;
     gap: 10px;
-    margin: 20px auto;
+    margin-top: 20px;    
+    margin-bottom: 20px; 
     padding: 0 10px;
 }
 
 .btn-attend {
-    width: 100px;
-    height: 50px;
-    padding: 10px 10px;
-    border: 1px solid transparent;
-    background-color: #ffffff00;
-    border-color: #838181a8;
+    padding: 0.6rem 1.2rem; 
+    border: 1px solid #838181a8;
+    background-color: rgba(255, 255, 255, 0);
     color: #838181a8;
-    font-size: 16px;
+    font-size: 1rem; 
     cursor: pointer;
     transition: background-color 0.3s, color 0.3s;
+    min-width: 80px; 
+    max-width: 100px; 
+    width: auto; 
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-
-.btn-attend.active {
-    background-color: #ffffff00;
-    color: #052940;
-    border-color: #052940;
-    box-shadow: 0px 0px 3px #0b4264;
-    font-weight: 530;
-}
-
-.btn-attend.manage {
-    background-color: #ffffff00;
-    color: #052940;
-    border-color: #052940;
-    box-shadow: 0px 0px 3px #0b4264;
-    font-weight: 530;
-}
-
-.btn-attend.manage_all {
-    background-color: #ffffff00;
-    color: #052940;
-    border-color: #052940;
-    box-shadow: 0px 0px 3px #0b4264;
-    font-weight: 530;
-}
-
+.btn-attend.active,
+.btn-attend.manage,
+.btn-attend.manage_all,
 .btn-attend.manage_class {
-    background-color: #ffffff00;
+    background-color: rgba(255, 255, 255, 0);
     color: #052940;
     border-color: #052940;
     box-shadow: 0px 0px 3px #0b4264;
     font-weight: 530;
+    padding: 0.6rem 1.2rem; 
+    font-size: 1rem; 
+    min-width: 80px; 
+    max-width: 100px; 
+    width: auto; 
+    box-sizing: border-box;
 }
+
+
+
+
 
 .line-container1 {
     width: 100%;
@@ -391,6 +384,57 @@
         width: 95%; 
         max-width: 100%; 
         height: auto; 
+    }
+}
+
+@media (max-width: 768px) {
+    .btn-attend {
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+        min-width: 70px;
+        max-width: 90px; 
+    }
+
+    .btn-attend.active,
+    .btn-attend.manage,
+    .btn-attend.manage_all,
+    .btn-attend.manage_class {
+        padding: 0.5rem 1rem;
+        font-size: 0.9rem;
+        min-width: 70px;
+        max-width: 90px; 
+    }
+
+    .button-container,
+    .cza_button_container {
+        margin-top: 15px; 
+        
+    }
+}
+
+/* 모바일 화면 */
+@media (max-width: 480px) {
+    .btn-attend {
+        padding: 0.4rem 0.8rem;
+        font-size: 0.8rem;
+        min-width: 60px;
+        max-width: 80px; /* max-width을 80px으로 감소 */
+    }
+
+    .btn-attend.active,
+    .btn-attend.manage,
+    .btn-attend.manage_all,
+    .btn-attend.manage_class {
+        padding: 0.4rem 0.8rem;
+        font-size: 0.8rem;
+        min-width: 60px;
+        max-width: 80px; 
+    }
+
+    .button-container,
+    .cza_button_container {
+        margin-top: 10px; 
+        
     }
 }
 


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [ ] 새로운 기능
- [X] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항

 .btn-attend 버튼 너비 표준화:
 기본 max-width를 100px으로 설정하여 모든 버튼의 최대 너비를 일관되게 유지
  width 속성을 auto로 변경하여 부모 컨테이너에 의존하지 않고 내용에 맞게 크기가 조정되도록 설정
  반응형 디자인 개선
  
  미디어 쿼리 적용:
  768px 이하: max-width를 90px으로 감소시키고, 패딩과 폰트 크기 조정
  480px 이하: max-width를 80px으로 감소시키고, 패딩과 폰트 크기 추가 조정
  버튼 컨테이너 상단 여백 조정

  .button-container 및 .cza_button_container 클래스의 margin-top 값을 줄여, 화면 크기가 줄어들 때 상 
 단 여백만 감소
  하단 여백(margin-bottom)은 기존 값 유지

## 관련 이슈

- #152 

## 체크리스트

- [X] 테스트 코드를 작성하였나요?
- [X] 모든 테스트가 통과하나요?
- [X] 관련 문서를 업데이트했나요?
- [X] 코드 컨벤션을 지켰나요?

## 스크린샷**기존**

<img width="294" alt="스크린샷 2025-01-31 오후 4 51 24" src="https://github.com/user-attachments/assets/b1f68fcd-7e25-4f14-a2c7-47d95e3ed8b3" />

**수정**
<img width="363" alt="스크린샷 2025-01-31 오후 6 05 02" src="https://github.com/user-attachments/assets/6923bb2b-bc6c-429a-9c39-9f44d8a36863" />


## 기타

