### PR TITLE
[BE-#173] 학과 조교 권한으로 출석부 데이터를 XL파일로 반환하는 2개(코딩존1,코딩존2) API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:3.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseCode.java
@@ -34,6 +34,7 @@ public interface ResponseCode {
     //HTTP Status 500
     String MAIL_FAIL = "MF";
     String DATABASE_ERROR = "DBE";
+    String INTERNAL_SERVER_ERROR = "ISE";
 
     String DOES_NOT_MATCH_EMAIL = "DNME";
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/common/ResponseMessage.java
@@ -34,6 +34,7 @@ public interface ResponseMessage {
         String MAIL_FAIL = "Mail send Failed.";
         String DATABASE_ERROR = "Database error.";
         String DOES_NOT_MATCH_EMAIL ="Doesn't Match Email.";
+        String INTERNAL_SERVER_ERROR = "Internal Server Error.";
 
 
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/CodingZoneClass1Controller.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/CodingZoneClass1Controller.java
@@ -1,4 +1,4 @@
-package com.icehufs.icebreaker.domain.codingzone.controller;
+package com.icehufs.icebreaker.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/CodingZoneClass2Controller.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/CodingZoneClass2Controller.java
@@ -1,4 +1,4 @@
-package com.icehufs.icebreaker.domain.codingzone.controller;
+package com.icehufs.icebreaker.domain.auth.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -123,7 +123,21 @@ public class EntireAdminController {
             ByteArrayResource excelFile = codingzoneService.generateAttendanceExcelOfGrade1();
 
             return ResponseEntity.ok()
-                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=codingzone1.xlsx") // 클라이언트가 이 요청을 받으면 파일을 자동으로 다운로드하도록 설정
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=CodingZone1.xlsx") // 클라이언트가 이 요청을 받으면 파일을 자동으로 다운로드하도록 설정
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM) // 바이너리 파일(엑셀, PDF 등) 전송에 적합한 MIME 타입.
+                    .body(excelFile);
+        } catch (IOException e) {
+            return DownloadArticleExcelResponseDto.failed();
+        }
+    }
+
+    @GetMapping("/excel/attendance/grade2")
+    public ResponseEntity<?> downloadArticleExcel2() {
+        try {
+            ByteArrayResource excelFile = codingzoneService.generateAttendanceExcelOfGrade2();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=CodingZone2.xlsx") // 클라이언트가 이 요청을 받으면 파일을 자동으로 다운로드하도록 설정
                     .contentType(MediaType.APPLICATION_OCTET_STREAM) // 바이너리 파일(엑셀, PDF 등) 전송에 적합한 MIME 타입.
                     .body(excelFile);
         } catch (IOException e) {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/EntireAdminController.java
@@ -1,7 +1,11 @@
 package com.icehufs.icebreaker.domain.auth.controller;
 
+import com.icehufs.icebreaker.domain.codingzone.dto.response.*;
 import jakarta.validation.Valid;
 
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,15 +21,9 @@ import com.icehufs.icebreaker.domain.codingzone.dto.request.CodingZoneClassAssig
 import com.icehufs.icebreaker.domain.codingzone.dto.request.GroupInfUpdateRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.HandleAuthRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.PatchGroupInfRequestDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneClassAssignResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DeleteAllInfResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DeleteClassResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DepriveAuthResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetCodingZoneStudentListResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetListOfGroupInfResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GiveAuthResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GroupInfUpdateResponseDto;
 import com.icehufs.icebreaker.domain.codingzone.service.CodingZoneService;
+
+import java.io.IOException;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -117,5 +115,19 @@ public class EntireAdminController {
     ) {
         ResponseEntity<? super DepriveAuthResponseDto> response = codingzoneService.depriveAuth(email, requestBody);
         return response;
+    }
+
+    @GetMapping("/excel/attendance/grade1")
+    public ResponseEntity<?> downloadArticleExcel() {
+        try {
+            ByteArrayResource excelFile = codingzoneService.generateAttendanceExcelOfGrade1();
+
+            return ResponseEntity.ok()
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=codingzone1.xlsx") // 클라이언트가 이 요청을 받으면 파일을 자동으로 다운로드하도록 설정
+                    .contentType(MediaType.APPLICATION_OCTET_STREAM) // 바이너리 파일(엑셀, PDF 등) 전송에 적합한 MIME 타입.
+                    .body(excelFile);
+        } catch (IOException e) {
+            return DownloadArticleExcelResponseDto.failed();
+        }
     }
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/DownloadArticleExcelResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/DownloadArticleExcelResponseDto.java
@@ -5,6 +5,7 @@ import com.icehufs.icebreaker.common.ResponseCode;
 import com.icehufs.icebreaker.common.ResponseMessage;
 
 import lombok.Getter;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/DownloadArticleExcelResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/dto/response/DownloadArticleExcelResponseDto.java
@@ -1,0 +1,27 @@
+package com.icehufs.icebreaker.domain.codingzone.dto.response;
+
+import com.icehufs.icebreaker.common.ResponseDto;
+import com.icehufs.icebreaker.common.ResponseCode;
+import com.icehufs.icebreaker.common.ResponseMessage;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class DownloadArticleExcelResponseDto extends ResponseDto {
+
+    private DownloadArticleExcelResponseDto() {
+        super(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+    }
+
+    public static ResponseEntity<DownloadArticleExcelResponseDto> success() {
+        DownloadArticleExcelResponseDto result = new DownloadArticleExcelResponseDto();
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    public static ResponseEntity<ResponseDto> failed() {
+        ResponseDto result = new ResponseDto(ResponseCode.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(result);
+    }
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneRegisterRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/repository/CodingZoneRegisterRepository.java
@@ -13,4 +13,5 @@ public interface CodingZoneRegisterRepository extends JpaRepository<CodingZoneRe
     List<CodingZoneRegister> findByGrade(int grade);
     List<CodingZoneRegister> findByUserEmail(String userEmail);
     List<CodingZoneRegister> findAllByOrderByUserStudentNumAsc();
+    List<CodingZoneRegister> findByGradeOrderByUserStudentNumAsc(int grade);
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -1,30 +1,15 @@
 package com.icehufs.icebreaker.domain.codingzone.service;
 
+import com.icehufs.icebreaker.domain.codingzone.dto.response.*;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.ResponseEntity;
 
 import com.icehufs.icebreaker.domain.codingzone.dto.request.CodingZoneClassAssignRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.GroupInfUpdateRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.HandleAuthRequestDto;
 import com.icehufs.icebreaker.domain.codingzone.dto.request.PatchGroupInfRequestDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.AuthorityExistResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneCanceResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneClassAssignResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.CodingZoneRegisterResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DeleteAllInfResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DeleteClassResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.DepriveAuthResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetCodingZoneAssitantListResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetCodingZoneStudentListResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetCountOfAttendResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetListOfCodingZoneClassForNotLogInResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetListOfCodingZoneClassResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetListOfGroupInfResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetPersAttendListItemResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GetReservedClassListItemResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GiveAuthResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.GroupInfUpdateResponseDto;
-import com.icehufs.icebreaker.domain.codingzone.dto.response.PutAttendanceResponseDto;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface CodingZoneService {
@@ -38,6 +23,7 @@ public interface CodingZoneService {
     ResponseEntity<? super DeleteAllInfResponseDto> deleteAll(String email);
     ResponseEntity<? super GiveAuthResponseDto> giveAuth(String email, HandleAuthRequestDto dto);
     ResponseEntity<? super DepriveAuthResponseDto> depriveAuth(String email,HandleAuthRequestDto dto);
+    ByteArrayResource generateAttendanceExcelOfGrade1() throws IOException;
 
     //권한이 필요없는 로직
     ResponseEntity<? super AuthorityExistResponseDto> authExist(String email);

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneService.java
@@ -24,6 +24,7 @@ public interface CodingZoneService {
     ResponseEntity<? super GiveAuthResponseDto> giveAuth(String email, HandleAuthRequestDto dto);
     ResponseEntity<? super DepriveAuthResponseDto> depriveAuth(String email,HandleAuthRequestDto dto);
     ByteArrayResource generateAttendanceExcelOfGrade1() throws IOException;
+    ByteArrayResource generateAttendanceExcelOfGrade2() throws IOException;
 
     //권한이 필요없는 로직
     ResponseEntity<? super AuthorityExistResponseDto> authExist(String email);

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/implement/CodingZoneServiceImplement.java
@@ -726,4 +726,51 @@ public class CodingZoneServiceImplement implements CodingZoneService {
 
     }
 
+    @Override
+    public ByteArrayResource generateAttendanceExcelOfGrade2() throws IOException {
+        List<CodingZoneRegister> codingZoneRegisters;
+
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("코딩존1 출석부"); // 시트 이름 설정
+
+        // 헤더 생성 및 스타일 설정
+        Row headerRow = sheet.createRow(0);
+        String[] columns = {"학번", "이름", "수업 날짜", "수업 시간", "출/결석"};
+        CellStyle headerStyle = workbook.createCellStyle();
+        Font headerFont = workbook.createFont();
+        headerFont.setBold(true);
+        headerStyle.setFont(headerFont);
+
+        for (int i = 0; i < columns.length; i++) {
+            Cell cell = headerRow.createCell(i);
+            cell.setCellValue(columns[i]);
+            cell.setCellStyle(headerStyle);
+        }
+
+        // 코딩존1을 들은 모든 학생들을 학번순으로 불러오기
+        codingZoneRegisters = codingZoneRegisterRepository.findByGradeOrderByUserStudentNumAsc(2);
+
+        // 데이터 채우기
+        int rowNum = 1;
+        for (CodingZoneRegister register : codingZoneRegisters) {
+            Row row = sheet.createRow(rowNum++);
+            row.createCell(0).setCellValue(register.getUserStudentNum());
+            row.createCell(1).setCellValue(register.getUserName());
+
+            int classNum = register.getClassNum();
+            CodingZoneClass codingZoneClass = codingZoneClassRepository.findByClassNum(classNum);
+            row.createCell(2).setCellValue(codingZoneClass.getClassDate());
+            row.createCell(3).setCellValue(codingZoneClass.getClassTime());
+            row.createCell(4).setCellValue(register.getAttendance());
+        }
+
+        // 워크북을 바이트 배열로 변환
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        workbook.write(outputStream);
+        workbook.close();
+
+        return new ByteArrayResource(outputStream.toByteArray());
+
+    }
+
 }


### PR DESCRIPTION
## PR 종류

- [x] 새로운 기능

## 변경 사항

학과 조교 권한으로 출석부 데이터를 XL파일로 반환하는 API 2개( 코딩존 1, 코딩존 2) 구현 완료.
반환되는 XL파일의 속성 값으로 학번, 이름, 수업 날짜, 수업 시간, 출/결석 구성. (학번 오름차순으로 정렬됨)

DTO, Service, Repository, Controller 각 클래스에 새로운 API 관련 메서드 추가 및 새로운 ResponseCode 와 ResponseMessage 
INTERNAL_SERVER_ERROR = "ISE", String INTERNAL_SERVER_ERROR = "Internal Server Error." 추가 되었다.


## 관련 이슈

- #173 

## 체크리스트

- [x] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="841" alt="스크린샷 2025-02-11 오후 4 53 53" src="https://github.com/user-attachments/assets/015d6f77-0f97-49f1-8983-b483fad0f0fd" />

