### PR TITLE
[BE-#156] 일주일 간 최근 게시글 개수 반환 API 구현

### DIFF
--- a/backend/build/resources/main/application.properties
+++ b/backend/build/resources/main/application.properties
@@ -15,9 +15,9 @@ spring.redis.port=${REDIS_PORT}
 
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=110MB
-spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 
-# Gmail SMTP 설정
+# Gmail SMTP
 spring.mail.host = smtp.gmail.com
 spring.mail.port = 587
 spring.mail.username = ${MAIL_USERNAME}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/controller/ArticleController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/controller/ArticleController.java
@@ -22,6 +22,7 @@ import com.icehufs.icebreaker.domain.article.dto.response.DeleteArticleResponseD
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetCommentListResponseDto;
+import com.icehufs.icebreaker.domain.article.dto.response.GetRecentArticleNumDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetUserArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PatchArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PostArticleResponseDto;
@@ -85,6 +86,13 @@ public class ArticleController {
     @GetMapping("/list") // 모든 게시글 반환 API
     public ResponseEntity<? super GetArticleListResponseDto> getArticleList(){
         ResponseEntity<? super GetArticleListResponseDto> response = articleService.getArticleList();
+        return response;
+    }
+
+    @GetMapping("/list/recent")
+    public ResponseEntity<? super GetRecentArticleNumDto> getRecentArticleList() {
+        ResponseEntity<? super GetRecentArticleNumDto> response = articleService.getRecentArticleNum();
+        System.out.println("response = " + response);
         return response;
     }
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/domain/entity/Article.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/domain/entity/Article.java
@@ -1,11 +1,7 @@
 package com.icehufs.icebreaker.domain.article.domain.entity;
 
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-
+import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -53,8 +49,8 @@ public class Article {
     @Column(name = "view_count")
     private int viewCount;
 
-    @Column(name = "article_date")
-    private String articleDate;
+    @Column(name = "article_date", columnDefinition = "DATETIME")
+    private LocalDateTime articleDate;
 
     @Column(name = "auth_check")
     private int authCheck;
@@ -64,16 +60,12 @@ public class Article {
     private ArticleCategoryEnum category;
 
     public Article(PostArticleRequestDto dto, String email){
-        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        String writeDatetime = now.format(formatter);
-
         this.userEmail = email;
         this.articleTitle = dto.getArticleTitle();
         this.articleContent = dto.getArticleContent();
         this.likeCount = 0;
         this.viewCount = 0;
-        this.articleDate = writeDatetime;
+        this.articleDate = LocalDateTime.now();
         this.authCheck = 0;
         this.category = dto.getCategory();
     }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/object/ArticleListItem.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/object/ArticleListItem.java
@@ -1,6 +1,7 @@
 package com.icehufs.icebreaker.domain.article.dto.object;
 
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class ArticleListItem {
     private String articleContent;
     private int likeCount;
     private int viewCount;
-    private String articleDate;
+    private LocalDateTime articleDate;
     private int authCheck;
     private ArticleCategoryEnum category;
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/response/GetArticleResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/response/GetArticleResponseDto.java
@@ -1,5 +1,7 @@
 package com.icehufs.icebreaker.domain.article.dto.response;
 
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -15,19 +17,17 @@ import lombok.Getter;
 public class GetArticleResponseDto extends ResponseDto {
 
     private int articleNum;
-    //private String userEmail; 익명보장을 위해 글 작성자 메일을 아예 노출 x
     private String articleTitle;
     private String articleContent;
     private int likeCount;
     private int viewCount;
-    private String articleDate;
+    private LocalDateTime articleDate;
     private int authCheck;
     private ArticleCategoryEnum category;
 
     private GetArticleResponseDto(Article articleEntity){
         super(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
         this.articleNum = articleEntity.getArticleNum();
-        //this.userEmail = articleEntity.getUserEmail();
         this.articleTitle = articleEntity.getArticleTitle();
         this.articleContent = articleEntity.getArticleContent();
         this.likeCount = articleEntity.getLikeCount();

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/response/GetRecentArticleNumDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/dto/response/GetRecentArticleNumDto.java
@@ -1,0 +1,24 @@
+package com.icehufs.icebreaker.domain.article.dto.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.icehufs.icebreaker.common.ResponseCode;
+import com.icehufs.icebreaker.common.ResponseDto;
+import com.icehufs.icebreaker.common.ResponseMessage;
+
+import lombok.Getter;
+
+@Getter
+public class GetRecentArticleNumDto extends ResponseDto {
+	private final long recentArticleNum;
+	private GetRecentArticleNumDto(long recentArticleNum){
+		super(ResponseCode.SUCCESS, ResponseMessage.SUCCESS);
+		this.recentArticleNum = recentArticleNum;
+	}
+
+	public static ResponseEntity<GetRecentArticleNumDto> success(long recentArticleNum) {
+		GetRecentArticleNumDto result = new GetRecentArticleNumDto(recentArticleNum);
+		return ResponseEntity.status(HttpStatus.OK).body(result);
+	}
+}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/repository/ArticleRepository.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/repository/ArticleRepository.java
@@ -1,6 +1,8 @@
 package com.icehufs.icebreaker.domain.article.repository;
 
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +15,5 @@ public interface ArticleRepository extends JpaRepository<Article, Integer> {
     
     boolean existsByArticleNum(Integer articleNum); // 정확한 필드 이름을 사용
     Article findByArticleNum(Integer articleNum);   // 정확한 필드 이름을 사용
-
+    long countByArticleDateAfter(LocalDateTime localDateTime);
 }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/service/ArticleService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/service/ArticleService.java
@@ -14,6 +14,7 @@ import com.icehufs.icebreaker.domain.article.dto.response.DeleteCommentResponseD
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetCommentListResponseDto;
+import com.icehufs.icebreaker.domain.article.dto.response.GetRecentArticleNumDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetUserArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PatchArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PatchCommentResponseDto;
@@ -28,6 +29,7 @@ public interface ArticleService {
     ResponseEntity<? super PostArticleResponseDto> postArticleNotif(PostArticleRequestDto dto, String email);
     ResponseEntity<? super GetArticleResponseDto> getArticle(Integer articleNum);
     ResponseEntity<? super GetArticleListResponseDto> getArticleList();
+    ResponseEntity<? super GetRecentArticleNumDto> getRecentArticleNum();
     ResponseEntity<? super GetUserArticleListResponseDto> getUserArticleList(String email);
     ResponseEntity<? super PatchArticleResponseDto> patchArticle(PatchArticleRequestDto dto, Integer articleNum, String email);
     ResponseEntity<? super CheckOwnOfArticleResponseDto> checkOwnArtcle(String email, Integer articleNum);

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/article/service/implement/ArticleServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/article/service/implement/ArticleServiceImplement.java
@@ -1,5 +1,6 @@
 package com.icehufs.icebreaker.domain.article.service.implement;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +19,7 @@ import com.icehufs.icebreaker.domain.article.dto.response.DeleteCommentResponseD
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetCommentListResponseDto;
+import com.icehufs.icebreaker.domain.article.dto.response.GetRecentArticleNumDto;
 import com.icehufs.icebreaker.domain.article.dto.response.GetUserArticleListResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PatchArticleResponseDto;
 import com.icehufs.icebreaker.domain.article.dto.response.PatchCommentResponseDto;
@@ -101,6 +103,13 @@ public class ArticleServiceImplement implements ArticleService {
             return ResponseDto.databaseError();
         }
         return GetArticleListResponseDto.success(articleListViewEntities);
+    }
+
+    @Override
+    public ResponseEntity<? super GetRecentArticleNumDto> getRecentArticleNum() {
+        LocalDateTime oneWeekAgo = LocalDateTime.now().minusDays(7);
+        long count = articleRepository.countByArticleDateAfter(oneWeekAgo);
+        return GetRecentArticleNumDto.success(count);
     }
 
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,9 +15,9 @@ spring.redis.port=${REDIS_PORT}
 
 spring.servlet.multipart.max-file-size=100MB
 spring.servlet.multipart.max-request-size=110MB
-spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul
 
-# Gmail SMTP 설정
+# Gmail SMTP
 spring.mail.host = smtp.gmail.com
 spring.mail.port = 587
 spring.mail.username = ${MAIL_USERNAME}


### PR DESCRIPTION
## PR 종류

- [] 기능 개선
- [x] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 최근 일주일 간 게시글의 개수를 반환해주는 API를 구현했습니다.
- MySQL의 서버 타임존이 JPA연결이 UTC로 등록되어있어서 SEOUL로 수정하였습니다.

## 관련 이슈

- #156 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [x] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/461a5c74-f6af-441b-85b8-24c013ca8b0c" />

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
