### PR TITLE
[Refactor-#190] RT를 쿠키 반환으로 수정

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.icehufs.icebreaker.domain.auth.controller;
 
+import java.time.Duration;
+
 import jakarta.validation.Valid;
 
 import com.icehufs.icebreaker.domain.auth.dto.request.CheckCertificationRequestDto;
@@ -16,16 +18,14 @@ import com.icehufs.icebreaker.domain.auth.dto.response.RegenerateTokenResponseDt
 import com.icehufs.icebreaker.domain.auth.dto.response.SignInResponseDto;
 import com.icehufs.icebreaker.domain.auth.dto.response.SignUpResponseDto;
 
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
 import com.icehufs.icebreaker.domain.auth.service.AuthService;
-
 import lombok.RequiredArgsConstructor;
-
-
-
 
 @RestController
 @RequestMapping("/api/v1/auth") //일반 사용자를 위한 URL 주소(회원가입/로그인/이메일 인증/정지 확인)
@@ -45,14 +45,28 @@ public class AuthController {
     //메소드의 반환 타입과 값을 response로 선언
     //ResponseEntity는 HTTP 응답의 본문(body), 상태 코드(status code), 헤더(headers) 등을 포함
     //요청에 대한 응답을 보낼때 SignInResponseDto으로 미리정한 다양한 타입의 응답을 처리가능
-    public ResponseEntity<? super SignInResponseDto> signIn(@RequestBody @Valid SignInRequestDto requestBody){
+    public ResponseEntity<? super SignInResponseDto> signIn(
+        @RequestBody @Valid SignInRequestDto requestBody,
+        HttpServletResponse response){
         //@RequestBody 어노테이션은 HTTP 요청의 본문(body)을 SignInRequestDto 객체로 매핑
         //@Valid 요청 본문이 SignInRequestDto 클래스에 정의된 제약 조건들을 만족하는지 검증
-        ResponseEntity<? super SignInResponseDto> response = authService.signIn(requestBody);
-        return response;
+        ResponseEntity<? super SignInResponseDto> responseEntity
+            = authService.signIn(requestBody);
+        SignInResponseDto dto = (SignInResponseDto) responseEntity.getBody();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", dto.getRefreshToken())
+            .httpOnly(true)   // JavaScript에서 접근 불가 (XSS 방어)
+            .secure(false)     // 배포 시 true로 변경 예정, HTTPS 환경에서만 사용 가능
+            .sameSite("Strict") // CSRF 방어
+            .path("api/v1/auth/refresh") // 특정 경로에서만 접근 가능
+            .maxAge(Duration.ofDays(7)) // 7일간 유지
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return responseEntity;
     }
 
-    @PostMapping("/logout")
+    @DeleteMapping("/logout")
     public ResponseEntity<? super LogoutResponseDto> logout(@AuthenticationPrincipal String email) {
         ResponseEntity<? super LogoutResponseDto> response = authService.logout(email);
         return response;
@@ -60,9 +74,21 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<? super RegenerateTokenResponseDto> refresh(@AuthenticationPrincipal String email,
-        @RequestBody @Valid RegenerateTokenRequestDto requestBody) {
-        ResponseEntity<? super RegenerateTokenResponseDto> response = authService.refresh(requestBody, email);
-        return response;
+        @CookieValue(value = "refresh_token") String refreshToken,
+        HttpServletResponse response) {
+        ResponseEntity<? super RegenerateTokenResponseDto> responseEntity = authService.refresh(refreshToken, email);;
+        RegenerateTokenResponseDto dto = (RegenerateTokenResponseDto) responseEntity.getBody();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", dto.getRefreshToken())
+            .httpOnly(true)   // JavaScript에서 접근 불가 (XSS 방어)
+            .secure(false)     // 배포 시 true로 변경 예정, HTTPS 환경에서만 사용 가능
+            .sameSite("Strict") // CSRF 방어
+            .path("api/v1/auth/refresh") // 특정 경로에서만 접근 가능
+            .maxAge(Duration.ofDays(7)) // 7일간 유지
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return responseEntity;
     }
 
     @PostMapping("/email-certification") // 회원가입 시 인증 번호 전송 API

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 
 import com.icehufs.icebreaker.domain.auth.dto.request.CheckCertificationRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.EmailCertificationRequestDto;
-import com.icehufs.icebreaker.domain.auth.dto.request.RegenerateTokenRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.SignInRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.SignUpRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.response.CheckCertificationResponseDto;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/request/RegenerateTokenRequestDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/request/RegenerateTokenRequestDto.java
@@ -1,8 +1,0 @@
-package com.icehufs.icebreaker.domain.auth.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record RegenerateTokenRequestDto(
-	@NotBlank(message = "RT는 필수로 전달해야합니다.")
-	String refreshToken
-) {}

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/response/RegenerateTokenResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/response/RegenerateTokenResponseDto.java
@@ -3,6 +3,7 @@ package com.icehufs.icebreaker.domain.auth.dto.response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.icehufs.icebreaker.common.ResponseCode;
 import com.icehufs.icebreaker.common.ResponseDto;
 import com.icehufs.icebreaker.common.ResponseMessage;
@@ -13,6 +14,7 @@ import lombok.Getter;
 @Getter
 public class RegenerateTokenResponseDto extends ResponseDto {
 	private String accessToken;
+	@JsonIgnore // 직렬화 시 RT는 전달 안되게 설정, 현재 서비스 코드가 반환값이 코드 확장하기 어렵게 되어있음
 	private String refreshToken;
 	private int expirationTime;
 	private RegenerateTokenResponseDto(String accessToken, String refreshToken) {

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/response/SignInResponseDto.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/dto/response/SignInResponseDto.java
@@ -3,6 +3,7 @@ package com.icehufs.icebreaker.domain.auth.dto.response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.icehufs.icebreaker.common.ResponseCode;
 import com.icehufs.icebreaker.common.ResponseMessage;
 import com.icehufs.icebreaker.common.ResponseDto;
@@ -14,6 +15,7 @@ import lombok.Getter;
 public class SignInResponseDto extends ResponseDto { //ResponseDto의 code와 메시지에 토큰과 만료기간을 응답으로 반환
 
     private String accessToken;
+    @JsonIgnore // 직렬화 시 RT는 전달 안되게 설정, 현재 서비스 코드가 반환값이 코드 확장하기 어렵게 되어있음
     private String refreshToken;
     private int expirationTime;
 

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthService.java
@@ -23,7 +23,7 @@ public interface AuthService {
     ResponseEntity<? super SignUpResponseDto> signUp(SignUpRequestDto dto);
     ResponseEntity<? super SignInResponseDto> signIn(SignInRequestDto dto);
     ResponseEntity<? super LogoutResponseDto> logout(String email);
-    ResponseEntity<? super RegenerateTokenResponseDto> refresh(RegenerateTokenRequestDto dto, String email);
+    ResponseEntity<? super RegenerateTokenResponseDto> refresh(String refreshToken, String email);
     ResponseEntity<? super EmailCertificationResponseDto> emailCertification(EmailCertificationRequestDto dto);
     ResponseEntity<? super CheckCertificationResponseDto> checkCertification(CheckCertificationRequestDto dto);
     ResponseEntity<? super GiveUserBanResponseDto> giveUserBan(GiveUserBanRequestDto dto, Integer articleNum, String email);

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthService.java
@@ -3,7 +3,6 @@ package com.icehufs.icebreaker.domain.auth.service;
 import com.icehufs.icebreaker.domain.auth.dto.request.CheckCertificationRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.EmailCertificationRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.GiveUserBanRequestDto;
-import com.icehufs.icebreaker.domain.auth.dto.request.RegenerateTokenRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.SignInRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.request.SignUpRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.response.CheckCertificationResponseDto;

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/implement/AuthServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/implement/AuthServiceImplement.java
@@ -128,13 +128,13 @@ public class AuthServiceImplement implements AuthService {
     }
 
     @Override
-    public ResponseEntity<? super RegenerateTokenResponseDto> refresh(RegenerateTokenRequestDto dto, String email) {
+    public ResponseEntity<? super RegenerateTokenResponseDto> refresh(String refreshToken, String email) {
         try {
             if (email == null) {
                 return RegenerateTokenResponseDto.invalidToken();
             }
 
-            boolean isValid = refreshTokenService.vaildateRefreshToken(email, dto.refreshToken());
+            boolean isValid = refreshTokenService.vaildateRefreshToken(email, refreshToken);
             if (!isValid) {
                 return RegenerateTokenResponseDto.invalidToken();
             }

--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/implement/AuthServiceImplement.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/implement/AuthServiceImplement.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.icehufs.icebreaker.domain.auth.dto.object.JwtToken;
-import com.icehufs.icebreaker.domain.auth.dto.request.RegenerateTokenRequestDto;
 import com.icehufs.icebreaker.domain.auth.dto.response.LogoutResponseDto;
 import com.icehufs.icebreaker.domain.auth.dto.response.RegenerateTokenResponseDto;
 import com.icehufs.icebreaker.domain.auth.service.RefreshTokenService;


### PR DESCRIPTION
## PR 종류

- [ ] 기능 개선
- [ ] 새로운 기능
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 변경 사항
- 기존에 본문으로 전달되던 RT를 쿠키를 통해서 전달하게 하였습니다.  
- 기존에 Refresh API 호출 시 Refresh Token을 body로 전달하였는데 **수정 이후**에는 전달하지 않아도 괜찮습니다.
- POST로 작동하던 로그아웃 API를 DELETE로 수정하였습니다.  

## 관련 이슈

- #190 

## 체크리스트

- [ ] 테스트 코드를 작성하였나요?
- [ ] 모든 테스트가 통과하나요?
- [x] 관련 문서를 업데이트했나요?
- [x] 코드 컨벤션을 지켰나요?

## 스크린샷
### 로그인 API
<img width="869" alt="image" src="https://github.com/user-attachments/assets/14042d56-3c84-4fce-9d3c-e1e904e5e9bf" />  

### 쿠키에 저장되는 RT - 로그인, Refresh API에서 동일하게 작동됩니다.
<img width="876" alt="image" src="https://github.com/user-attachments/assets/79476f26-2978-4f44-b2a5-4a67c2b4e952" />  

### Refresh 토큰 재발급 API
<img width="858" alt="image" src="https://github.com/user-attachments/assets/22ca4c77-d37e-43e4-8ef7-637b599f1bbc" />  

### 로그아웃 API
<img width="855" alt="image" src="https://github.com/user-attachments/assets/1da10a57-5e2d-498f-8d41-23658b2ef67e" />  
 

## 기타

추가로 알려야 할 사항이 있다면 적어주세요.
