### PR TITLE
[FE-#285] 코딩존 색상 매핑

### DIFF
--- a/frontend/src/pages/Coding-zone/CodingZoneSetting.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneSetting.js
@@ -45,7 +45,7 @@ const ClassSetting = () => {
       alert("과목명이 입력된 항목이 없습니다.");
       return;
     }
-    // ★ ID→COLOR만 저장
+    // ID→COLOR만 저장
     const idColor = loadIdColorMap();
     cleaned.forEach((r) => {
       const id = String(parseInt(r.codingZone, 10));
@@ -54,7 +54,7 @@ const ClassSetting = () => {
     });
     saveIdColorMap(idColor);
 
-    // ★ CHANGED: 백엔드로 보낼 payload 생성(색상 제외)
+    // 백엔드로 보낼 payload 생성(색상 제외)
     const payload = cleaned.map((r) => ({
       subjectId: parseInt(r.codingZone, 10),
       subjectName: r.subjectName,

--- a/frontend/src/pages/Coding-zone/subjectColors.js
+++ b/frontend/src/pages/Coding-zone/subjectColors.js
@@ -49,7 +49,7 @@ export function getColorByName(subjectName, defaultColor = "#A0A0A0") {
   return (id && idColor?.[String(id)]) || defaultColor;
 }
 
-// (편의) 현재 ID의 색(저장된 값 없으면 기본값) 가져오기
+// 현재 ID의 색(저장된 값 없으면 기본값) 가져오기
 export function getCodingZoneColor(id) {
   return getColorById(id);
 }


### PR DESCRIPTION
## 📌 변경 사항
- 코딩존 번호와 과목명 매핑시 색상도 함께 매핑

## 🔍 상세 내용
<img width="1181" height="950" alt="image" src="https://github.com/user-attachments/assets/13373cc6-41a9-4a68-8ffb-84b700b59117" />
다음과 같이 "코딩존 등록 조회" 페이지와 "출결관리" 페이지에서는 과목 버튼을 누를때 hover의 색상이 모두 다릅니다. 따라서 코딩존 매핑 단계에서 subjectId -> 과목명 매핑, subjectId -> 색상 매핑 이 두 단계가 필요합니다.

이 로직은 "코딩존 등록 조회" 페이지와 "출결관리" 페이지에서 사용될 예정입니다.


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.


## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.


## 📎 참고 자료 (선택)
<img width="930" height="67" alt="image" src="https://github.com/user-attachments/assets/e56a628a-f2e2-48b0-bf3f-9548943f7e94" />
현재는 UI적으로 색상 매핑이 되었는지 확인할 방법이 없어서 개발자모드 콘솔로 확인한 모습입니다.