### PR TITLE
[FE-#297] 권한 부여/박탈 페이지에서 매핑된 과목만 선택 옵션에 표시되도록 수정

### DIFF
--- a/frontend/src/features/api/Admin/Codingzone/AuthApi.js
+++ b/frontend/src/features/api/Admin/Codingzone/AuthApi.js
@@ -4,7 +4,7 @@ import { refreshTokenRequest } from '../../../../shared/api/AuthApi';
 const DOMAIN = process.env.REACT_APP_API_DOMAIN;
 const API_DOMAIN_ADMIN = `${DOMAIN}/api/admin`;
 
-// 권한 부여 API (ATE 처리 추가)
+// 권한 부여 API  
 export const grantPermission = async (email, role, token, setCookie, navigate) => {
     try {
         const response = await axios.patch(`${API_DOMAIN_ADMIN}/authorities`, { email, role }, {
@@ -18,18 +18,12 @@ export const grantPermission = async (email, role, token, setCookie, navigate) =
         if (!error.response) {
             return { code: 'NETWORK_ERROR', message: '네트워크 상태를 확인해주세요.' };
         }
-
         const { code } = error.response.data;
-
         if (code === "ATE") {
-            console.warn("권한 부여: Access Token 만료됨. 토큰 재발급 시도 중...");
             const newToken = await refreshTokenRequest(setCookie, token, navigate);
-
             if (newToken?.accessToken) {
-
                 return grantPermission(email, role, newToken.accessToken, setCookie, navigate);
             } else {
-
                 setCookie('accessToken', '', { path: '/', expires: new Date(0) });
                 navigate('/');
                 return { code: 'TOKEN_EXPIRED', message: '토큰이 만료되었습니다. 다시 로그인해주세요.' };
@@ -40,38 +34,48 @@ export const grantPermission = async (email, role, token, setCookie, navigate) =
     }
 };
 
-// 권한 박탈 API (ATE 처리 추가)
+
+// 권한 박탈 API  
 export const deprivePermission = async (email, role, token, setCookie, navigate) => {
     try {
-        const response = await axios.patch(`${API_DOMAIN_ADMIN}/deprivation`, { email, role }, {
-            headers: { Authorization: `Bearer ${token}` }
-        });
-
-        if (response.data.code === "SU") {
-            return response.data;
+      const response = await axios.patch(
+        `${API_DOMAIN_ADMIN}/authorities/deprivation`,
+        { email, role },
+        {
+          headers: { Authorization: `Bearer ${token}` }
         }
+      );
+      const { code, message } = response.data;
+      switch (code) {
+        case "SU": 
+          return { code, message };
+        case "NS":  
+          return { code, message};
+        case "DBE":  
+        return { code, message};
+        case "PE":  
+        return { code, message};
+        default:  
+        return { code, message};
+      }
     } catch (error) {
-        if (!error.response) {
-            return { code: 'NETWORK_ERROR', message: '네트워크 상태를 확인해주세요.' };
+      if (!error.response) {
+        return { code: "NETWORK_ERROR", message: "네트워크 상태를 확인해주세요." };
+      }
+
+      const { code, message } = error.response.data;
+
+      if (code === "ATE") {
+        const newToken = await refreshTokenRequest(setCookie, token, navigate);
+        if (newToken?.accessToken) {
+          return deprivePermission(email, role, newToken.accessToken, setCookie, navigate);
+        } else {
+          setCookie("accessToken", "", { path: "/", expires: new Date(0) });
+          navigate("/");
+          return { code: "TOKEN_EXPIRED", message: "토큰이 만료되었습니다. 다시 로그인해주세요." };
         }
-
-        const { code } = error.response.data;
-
-        if (code === "ATE") {
-            console.warn("🔄 권한 박탈: Access Token 만료됨. 토큰 재발급 시도 중...");
-            const newToken = await refreshTokenRequest(setCookie, token, navigate);
-
-            if (newToken?.accessToken) {
-
-                return deprivePermission(email, role, newToken.accessToken, setCookie, navigate);
-            } else {
-
-                setCookie('accessToken', '', { path: '/', expires: new Date(0) });
-                navigate('/');
-                return { code: 'TOKEN_EXPIRED', message: '토큰이 만료되었습니다. 다시 로그인해주세요.' };
-            }
-        }
-
-        return error.response.data;
+      }
+      return { code, message };
     }
-};
+  };
+  

--- a/frontend/src/features/api/Admin/Codingzone/ClassApi.js
+++ b/frontend/src/features/api/Admin/Codingzone/ClassApi.js
@@ -206,7 +206,7 @@ export const registerSubjectMapping = async (mappings, accessToken, setCookie, n
         authorization(accessToken)
       );
   
-      if (response.data.code === 'SU') {
+      if (response.data.code === 'SUCCESS_POST_MAPPING') {
         return { success: true, message: response.data.message };
       } else {
         return { success: false, message: response.data.message };
@@ -237,14 +237,72 @@ export const registerSubjectMapping = async (mappings, accessToken, setCookie, n
           return { success: false, message: '권한이 없습니다.' };
         case 'DBE':
           return { success: false, message: '데이터베이스 오류가 발생했습니다.' };
-        case 'ALREADY_EXISTED_CLASSMAPPING':
+        case 'DUPLICATED_MAPPING_SET':
           return { success: false, message: '이미 존재하는 코딩존 매핑 번호와 교과목입니다.' };
-        case 'ALREADY_EXISTED_NUMMAPPING':
+        case 'DUPLICATED_MAPPING_NUMBER':
           return { success: false, message: '이미 존재하는 subjectId입니다.' };
-        case 'ALREADY_EXISTED_MAPPINGSET':
+        case 'DUPLICATED_MAPPING_CLASSNAME':
           return { success: false, message: '이미 존재하는 subjectName입니다.' };
         default:
           return { success: false, message: '예상치 못한 오류가 발생했습니다.' };
+      }
+    }
+  };
+  //과목명과 코딩존 번호 매핑불러오는 api
+  export const getSubjectMappingList = async (accessToken, setCookie, navigate) => {
+    console.log("📌 getSubjectMappingList 호출됨, accessToken:", accessToken);
+    try {
+      const response = await axios.get(
+        `${API_DOMAIN_ADMIN}/subjects`, authorization(accessToken)
+      );
+  
+      if (response.data.code === 'SU') {
+        return {
+          success: true,
+          message: response.data.message,
+          subjectList: Array.isArray(response.data.data) ? response.data.data : []
+        };
+      } else {
+        return { success: false, message: response.data.message, subjectList: [] };
+      }
+    } catch (error) {
+      if (!error.response || !error.response.data) {
+        return {
+          success: false,
+          message: '네트워크 오류 또는 서버 응답 없음',
+          subjectList: []
+        };
+      }
+  
+      const { code } = error.response.data;
+  
+      // 토큰 만료 처리
+      if (code === 'ATE') {
+        console.warn('코딩존 매핑 조회: Access Token 만료됨. 토큰 재발급 시도 중...');
+        const newToken = await refreshTokenRequest(setCookie, accessToken, navigate);
+  
+        if (newToken?.accessToken) {
+          return getSubjectMappingList(newToken.accessToken, setCookie, navigate);
+        } else {
+          setCookie('accessToken', '', { path: '/', expires: new Date(0) });
+          navigate('/');
+          return {
+            success: false,
+            message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+            subjectList: []
+          };
+        }
+      }
+  
+      switch (code) {
+        case 'AF':
+          return { success: false, message: '권한이 없습니다.', subjectList: [] };
+        case 'DBE':
+          return { success: false, message: '데이터베이스 오류가 발생했습니다.', subjectList: [] };
+        case 'NOT_ANY_MAPPINGSET':
+          return { success: false, message: '등록된 매핑 정보가 없습니다.', subjectList: [] };
+        default:
+          return { success: false, message: '예상치 못한 오류가 발생했습니다.', subjectList: [] };
       }
     }
   };

--- a/frontend/src/pages/Coding-zone/CodingZoneSetting.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneSetting.js
@@ -14,9 +14,9 @@ import {
 } from "./subjectColors";
 
 const ClassSetting = () => {
-  const [cookies, setCookie] = useCookies(["accessToken"]); // ✅ 정의됨
+  const [cookies, setCookie] = useCookies(["accessToken"]); 
   const accessToken = cookies.accessToken;
-  const navigate = useNavigate(); // ✅ 정의됨
+  const navigate = useNavigate();  
 
   const [rows, setRows] = useState([
     { id: Date.now(), codingZone: "1", subjectName: "" },
@@ -42,7 +42,7 @@ const ClassSetting = () => {
       .filter((r) => r.subjectName !== "");
 
     if (cleaned.length === 0) {
-      alert("과목명이 입력된 항목이 없습니다.");
+      alert("과목명이 입력되지 않았습니다.");
       return;
     }
     // ID→COLOR만 저장


### PR DESCRIPTION
## 📌 변경 사항
- 권한 부여/박탈 페이지에서 매핑된 과목만 선택 옵션에 표시되도록 수정
- 불필요한 과목 옵션 제거로 잘못된 권한 부여 가능성 방지
- getSubjectMappingList API 연동 및 상태 관리 로직 추가

## 🔍 상세 내용
- 컴포넌트 마운트 시 getSubjectMappingList 호출하여 subjectList를 상태에 저장
- 권한 선택 <select> 항목에서 기존 하드코딩 옵션 대신, API로 받은 매핑 과목만 동적 렌더링

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
 
