### PR TITLE
[FE-#306] NavigationBar, BoardBar 여백 수정

### DIFF
--- a/frontend/src/shared/ui/Banner/Banner.css
+++ b/frontend/src/shared/ui/Banner/Banner.css
@@ -4,7 +4,7 @@
   height: auto;
   padding: 0px 10px;
   box-sizing: border-box;
-  margin: 28px 0 0 0;
+  margin: 39px 0 0 0;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -29,56 +29,56 @@
   height: auto;
   max-height: 400px;
   object-fit: cover;
-  margin: -20px auto 0 auto;
+  margin: -7px auto 0 auto;
 }
 
 /* 반응형 */
 /* ≤ 1280px 반응형 */
 @media (max-width: 1280px) {
   .banner_img_container {
-    margin: 28px 0 95px 0;
+    margin: 33px 0 0 0;
   }
   .banner_img_container .banner {
     max-height: 346px;
   }
   .codingzonetop2-image {
     max-width: 960px;
-    margin: -16px auto -10px auto;
+    margin: -9px auto -10px auto;
   }
 }
 
 /* ≤ 1024px 반응형 */
 @media (max-width: 1024px) {
   .banner_img_container {
-    margin: 25px 0 85px 0;
+    margin: 31px 0 0 0;
   }
   .banner_img_container .banner {
     max-height: 288px;
   }
   .codingzonetop2-image {
     max-width: 795px;
-    margin: -15px auto -13px auto;
+    margin: -10px auto -13px auto;
   }
 }
 
 /* ≤ 768px 반응형 */
 @media (max-width: 768px) {
   .banner_img_container {
-    margin: 23px 0 58px 0;
+    margin: 27px 0 0 0;
   }
   .banner_img_container .banner {
     max-height: 240px;
   }
   .codingzonetop2-image {
     max-width: 671px;
-    margin: -14px auto -10px auto;
+    margin: -11px auto -10px auto;
   }
 }
 
 /* ≤ 480px 반응형 */
 @media (max-width: 480px) {
   .banner_img_container {
-    margin: 20px 0 38px 0;
+    margin: 23px 0 0 0;
   }
   .banner_img_container .banner {
     max-height: 150px;

--- a/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
+++ b/frontend/src/shared/ui/boardbar/CodingZoneBoardbar.css
@@ -2,7 +2,7 @@
 .cza_button_container {
   display: flex; /* 기본값 : row */
   width: 100%;
-  margin: 3.4rem 0 1.0625rem 0;
+  margin: 1.7rem 0 1.0625rem 0;
   justify-content: center;
   align-items: center;
   gap: 1.875rem;
@@ -52,7 +52,7 @@
 
 /* 일반 학생 전용 버튼 컨테이너 */
 .cza_button_container.student {
-  margin: 2.5rem 0 1.5rem 0;
+  margin: 2rem 0 1.5rem 0;
   margin-inline: auto;
 }
 
@@ -60,7 +60,10 @@
 .btn-attend.student {
   padding: 0.85em 1.6em;
   margin-inline: auto;
+  position: relative;
+  left: 9.5px;
 }
+
 /* 학생 전용일 땐 구분선 제거 */
 .cza_button_container.student .divider {
   display: none;
@@ -70,39 +73,45 @@
 /* ≤ 1280px 반응형 */
 @media (max-width: 1280px) {
   .cza_button_container {
-    margin: 0 0 0.84rem 0;
+    margin: 1.7 0 0.84rem 0;
   }
   .btn-attend {
     font-size: 0.9rem;
   }
   .cza_button_container.student {
-    margin: 0rem 0 1.7rem 0;
+    margin: 1.5rem 0 1.7rem 0;
+    position: relative;
+    right: 0.2px;
   }
 }
 
 /* ≤ 1024px 반응형 */
 @media (max-width: 1024px) {
   .cza_button_container {
-    margin: 0.4rem 0 0.7rem 0;
+    margin: 1.95rem 0 0.7rem 0;
   }
   .btn-attend {
     font-size: 0.74rem;
   }
   .cza_button_container.student {
-    margin: 0.1rem 0 1.6rem 0;
+    margin: 1.3rem 0 1.6rem 0;
+    position: relative;
+    right: 0.1rem;
   }
 }
 
 /* ≤ 768px 반응형 */
 @media (max-width: 768px) {
   .cza_button_container {
-    margin: 0.7rem 0 0.7rem 0;
+    margin: 1.85rem 0 0.7rem 0;
   }
   .btn-attend {
     font-size: 0.7rem;
   }
   .cza_button_container.student {
-    margin: 0.1rem 0 1.6rem 0;
+    margin: 1.3rem 0 1.6rem 0;
+    position: relative;
+    right: 0.28rem;
   }
 }
 
@@ -112,7 +121,7 @@
     flex-wrap: wrap; /* 줄바꿈 허용 */
     justify-content: center;
     gap: 0.75rem;
-    margin: 0.7rem 0 0.35rem 0;
+    margin: 1.4rem 0 0.35rem 0;
   }
 
   /* 세로 구분선 숨김 */
@@ -128,12 +137,14 @@
     font-size: 0.55rem;
   }
   .cza_button_container.student {
-    margin: 0.35rem 0 1.5rem 0;
+    margin: 1.2rem 0 1.5rem 0;
+    position: relative;
+    right: 0.315rem;
   }
 
   .cza_button_container.student .btn-attend.student {
     flex: 0 0 auto;
     width: auto;
-    padding: 0.6rem 1.2rem !important;
+    padding: 0.5rem 1rem !important;
   }
 }

--- a/frontend/src/widgets/layout/Header/Navbar.css
+++ b/frontend/src/widgets/layout/Header/Navbar.css
@@ -1,7 +1,7 @@
 .navbar {
   width: 100%;
   padding: 0 110px;
-  margin: 0 0 66px 0;
+  margin: 0 0 30px 0;
 }
 
 .header-container {
@@ -51,7 +51,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1280px) {
   .navbar {
     padding: 0 80px;
-    margin: 0 0 54px 0;
+    margin: 0 0 25px 0;
   }
   .header-container {
     padding: 89px 0 12px 12px;
@@ -68,7 +68,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 1024px) {
   .navbar {
     padding: 0 60px;
-    margin: 0 0 45px 0;
+    margin: 0 0 24px 0;
   }
   .header-container {
     padding: 70px 0 12px 13px;
@@ -85,7 +85,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 768px) {
   .navbar {
     padding: 0 40px;
-    margin: 0 0 33px 0;
+    margin: 0 0 19px 0;
   }
   .header-container {
     padding: 48px 0 8px 14px;
@@ -102,7 +102,7 @@ nav.navbar .nav-link[data-open="true"] {
 @media (max-width: 480px) {
   .navbar {
     padding: 0 20px;
-    margin: 0 0 25px 0;
+    margin: 0 0 14px 0;
   }
   .header-container {
     padding: 28px 0 7px 15px;


### PR DESCRIPTION
## 📌 변경 사항
- NavigationBar와 BoardBar 주변 여백을 수정하였습니다!

## 🔍 상세 내용
- 기존에 제가 구현해놨던 NavigationBar.css와 BoardBar.css의 margin을 수정하였습니다!

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- NavigationBar와 BoardBar 주변 여백이 괜찮은지 봐주시면 감사하겠습니다!

## 📎 참고 자료 (선택)

### 1. 코딩존 예약 페이지
<img width="1288" height="946" alt="스크린샷 2025-08-11 오후 11 19 43" src="https://github.com/user-attachments/assets/6f5a68dd-f370-46dd-84e5-f55d4bc5c981" />

### 2. 출결 관리 페이지 (과사 조교)
<img width="1288" height="946" alt="스크린샷 2025-08-11 오후 11 19 48" src="https://github.com/user-attachments/assets/e98740ff-28af-4476-ad37-272ecb888024" />

### 3. 코딩존 예약 페이지 (모바일 ver)
<img width="381" height="454" alt="스크린샷 2025-08-11 오후 11 20 00" src="https://github.com/user-attachments/assets/6cfe47db-ba6c-4110-b11d-00b9077b0c00" />

### 4. 출결 관리 페이지 (과사 조교, 모바일 ver)
<img width="673" height="862" alt="스크린샷 2025-08-11 오후 11 20 10" src="https://github.com/user-attachments/assets/72c9818e-d9b4-4b38-88a3-a0438f597924" />
