### PR TITLE
fix : 코딩존 조교 권한이 중복 부여 되지 않도록 수정

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthorityService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthorityService.java
@@ -22,8 +22,8 @@ public class AuthorityService {
 
     public String giveAuth(String email, HandleAuthRequestDto dto) {
         Authority granteeAuthority = validateGrantorAndGranteeExist(email, dto);
-        boolean hasRole = granteeAuthority.hasRole(dto.getRole());
-        if (hasRole) throw new BusinessException(ResponseCode.PERMITTED_ERROR, "이미 해당 권한을 가진 사용자.", HttpStatus.CONFLICT);
+        granteeAuthority.getClassAdminAuth()
+                .ifPresent(auth -> {throw new BusinessException(ResponseCode.PERMITTED_ERROR, "이미 해당 권한을 가진 사용자.", HttpStatus.CONFLICT);});
         granteeAuthority.grantRole(dto.getRole());
         authorityRepository.save(granteeAuthority);
         return "권한 부여 성공.";
@@ -31,8 +31,8 @@ public class AuthorityService {
 
     public String depriveAuth(String email, HandleAuthRequestDto dto) {
         Authority granteeAuthority = validateGrantorAndGranteeExist(email, dto);
-        boolean hasRole = granteeAuthority.hasRole(dto.getRole());
-        if (!hasRole) throw new BusinessException(ResponseCode.PERMITTED_ERROR, "이미 권한이 없는 사용자", HttpStatus.CONFLICT);
+        granteeAuthority.getClassAdminAuth()
+                .orElseThrow(() -> new BusinessException(ResponseCode.PERMITTED_ERROR, "이미 권한이 없는 사용자", HttpStatus.CONFLICT));
         granteeAuthority.revokeRole(dto.getRole());
         authorityRepository.save(granteeAuthority);
         return "권한 박탈 성공.";


### PR DESCRIPTION
## 📌 변경 사항
한 유저에게 코딩존 조교 권한이 중복 부여 될 수 있음

## 🔍 상세 내용
중복 되여 되지 않도록 수정하고, 권한 박탈도 리펙토링 했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
close #396 
