### PR TITLE
[FE-#401] 출결 관리 페이지 디자인 수정

### DIFF
--- a/frontend/src/pages/Coding-zone/CodingZoneAttendanceEA.js
+++ b/frontend/src/pages/Coding-zone/CodingZoneAttendanceEA.js
@@ -50,6 +50,27 @@ const CodingZoneAttendanceAssistant = () => {
   const [students, setStudents] = useState([]); // ★ 학생 리스트
   const [isStudentsLoading, setIsStudentsLoading] = useState(false); // ★ 학생 로딩
 
+  function BackButton({ label = "뒤로가기", onClick }) {
+    const [icon, setIcon] = React.useState("/leftnone.png");
+
+    return (
+      <button
+        type="button"
+        className="return return-back"
+        onClick={onClick}
+        onMouseEnter={() => setIcon("/left.png")}
+        onMouseLeave={() => setIcon("/leftnone.png")}
+        onMouseDown={() => setIcon("/left.png")}
+        onMouseUp={() => setIcon("/left.png")}
+        onFocus={() => setIcon("/left.png")}
+        onBlur={() => setIcon("/leftnone.png")}
+      >
+        <img src={icon} alt="" className="btn-icon" draggable="false" />
+        {label}
+      </button>
+    );
+  }
+
   const count = subjects.length;
   const gridClass =
     count === 4
@@ -361,9 +382,8 @@ const CodingZoneAttendanceAssistant = () => {
             </div>
 
             <div className="cz-classes-back">
-              <button
-                type="button"
-                className="btn-ghost"
+              <BackButton
+                label="과목 다시 선택하기"
                 onClick={() => {
                   setSelectedSubjectId(null);
                   setSelectedSubjectName("");
@@ -371,11 +391,8 @@ const CodingZoneAttendanceAssistant = () => {
                   setSelectedClassNum(null);
                   setStudents([]);
                 }}
-              >
-                ← 뒤로가기
-              </button>
+              />
             </div>
-
             <div className="manager-table-card">
               {isClassesLoading ? (
                 <div className="panel-gray">
@@ -427,17 +444,13 @@ const CodingZoneAttendanceAssistant = () => {
             </div>
 
             <div className="cz-classes-back">
-              <button
-                type="button"
-                className="btn-ghost"
+              <BackButton
+                label="수업 목록으로 돌아가기"
                 onClick={() => {
-                  // ← 수업 목록으로
                   setSelectedClassNum(null);
                   setStudents([]);
                 }}
-              >
-                ← 뒤로가기
-              </button>
+              />
             </div>
 
             <div className="manager-table-card">

--- a/frontend/src/pages/css/codingzone/codingzone_attend.css
+++ b/frontend/src/pages/css/codingzone/codingzone_attend.css
@@ -407,6 +407,10 @@
   margin-left: 0;
 }
 
+.return.return-back {
+  top: 0 !important; /* 덮어쓰기 */
+}
+
 .btn-ghost {
   background: #efefef;
   color: #adacac;


### PR DESCRIPTION
## 📌 변경 사항
- 과사조교 권한의 출결관리 페이지 디자인 수정

## 🔍 상세 내용
1️⃣ hover 색 변경
너무 연해서 잘 안보인다는 피드백을 받아 더 진한 색으로 수정

2️⃣ 뒤로가기 버튼 디자인 수정
코딩존 예약 페이지와 출결관리 페이지의 뒤로가기 디자인이 달랐는데, 코딩존 예약 페이지 디자인으로 통일했습니다.

<img width="1032" height="437" alt="image" src="https://github.com/user-attachments/assets/9a3f1417-77ff-4078-9d9c-1b838facbbb3" />


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

