### PR TITLE
fix : 문자열 직접 비교로 권한 판정으로 비즈니스 로직 수정

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthorityService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/auth/service/AuthorityService.java
@@ -55,17 +55,13 @@ public class AuthorityService {
         Authority authority = authorityRepository.findByEmail(email);
         if (authority == null) throw  new BusinessException(ResponseCode.NOT_EXISTED_USER, "권한을 부여할 수  있는 사용자가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED);
 
-        // 메서드 내부 전용 헬퍼 (null 안전 + trim + Y 체크)
-        final java.util.function.Predicate<String> isYes =
-                s -> s != null && "Y".equalsIgnoreCase(s.trim());
-
-        if (isYes.test(authority.getRoleAdmin())) {
+        if ("ROLE_ADMIN".equals(authority.getRoleAdmin())) {
             return new ResponseDto(ResponseCode.ENTIRE_ADMIN, ResponseMessage.ENTIRE_ADMIN);
         }
-        if (isYes.test(authority.getRoleAdminC1())
-                || isYes.test(authority.getRoleAdminC2())
-                || isYes.test(authority.getRoleAdminC3())
-                || isYes.test(authority.getRoleAdminC4())) {
+        if ("ROLE_ADMINC1".equals(authority.getRoleAdminC1())
+                || "ROLE_ADMINC2".equals(authority.getRoleAdminC2())
+                || "ROLE_ADMINC3".equals(authority.getRoleAdminC3())
+                || "ROLE_ADMINC4".equals(authority.getRoleAdminC4())) {
             return new ResponseDto(ResponseCode.CODING_ADMIN, ResponseMessage.CODING_ADMIN);
         }
 


### PR DESCRIPTION
## 📌 변경 사항
- null 체크로 권한 체크를 하는 방식보다는 권한 필드명으로 직접 검증하도록 수정했습니다.

## 🔍 상세 내용
- 불필요한 null 체크를 이용한 메서드 내 함수를 제거하고 직접 문자열로 검증하도록 수정했습니다.

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 없습니다. 
- 
## 📎 참고 자료 (선택)
- 없습니다.
