### PR TITLE
Hotfix : 코딩존 수업 수정 시 조 정보만 다르게 했을 때도 정상 수정되도록 로직 수정

### DIFF
--- a/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
+++ b/backend/src/main/java/com/icehufs/icebreaker/domain/codingzone/service/CodingZoneClassService.java
@@ -107,10 +107,10 @@ public class CodingZoneClassService {
         // 수정한 정보가 기존의 정보와 동일할 때 예외처리
         // 수정하고자 하는 코딩존 수업의 고유번호를 가져와서 DB확인
         CodingZoneClass existingClass = codingZoneClassRepository.findByClassNum(classNum);
-        if(dto.isSameEntity(existingClass)) throw new DuplicatedClassException();
-
         GroupInf existinfGroup = groupInfRepository.findByClassNum(existingClass.getClassNum())
                     .orElseThrow(GroupInfNotFoundException::new);
+
+        if(dto.isSameEntity(existingClass) && existinfGroup.getGroupId().equals(dto.getGroupId())) throw new DuplicatedClassException();
 
         // 수정한 정보가 이미 DB에 저장되어 있는 경우
         boolean isDuplicate = codingZoneClassRepository


### PR DESCRIPTION
## 📌 변경 사항
- 기존 수업 정보 수정 기능에서는 수정하고자 하는 정보에 조 정보(A/B)조만 다르게 입력했을 때, 변경된 정보가 없는 에러가 발생했습니다.
- 이는 codingzoneclass entity만 조회를 확인했기 때문입니다.
- 따라서 이번 수정에서는 codignzoneclass 뿐만 아니라 groupinf 또한 조회하여 조 정보만 다르게 입력했을 때도 정상적으로 수정 작업이 되도록 고쳤습니다.

## 🔍 상세 내용
- `CodingZoneClassService` 파일의 patchClassAndGroup() 메소드 내부 "변경된 정보 없음" 예외 발생하기 위한 조건 추가

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
